### PR TITLE
Added arm architecture for docker image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -20,5 +20,5 @@ jobs:
           file: ./Dockerfile
           context: ./
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm/v8
-          tags: ghcr.io/l480/cloudflare-dyndns:latest
+          platforms: linux/amd64,linux/arm/v6
+          tags: ghcr.io/${{ github.repository_owner }}/cloudflare-dyndns:latest

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -20,4 +20,5 @@ jobs:
           file: ./Dockerfile
           context: ./
           push: true
-          tags: ghcr.io/kseb/cloudflare-dyndns:latest
+          platforms: linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm/v8
+          tags: ghcr.io/l480/cloudflare-dyndns:latest

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Packages
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -20,4 +20,4 @@ jobs:
           file: ./Dockerfile
           context: ./
           push: true
-          tags: ghcr.io/l480/cloudflare-dyndns:latest
+          tags: ghcr.io/kseb/cloudflare-dyndns:latest


### PR DESCRIPTION
I wanted to run the docker image on a raspberry pi but the image for the correct architecture was missing. With this change it is automatically added by github actions.