### PR TITLE
Update all subdomains with the same IP by omitting RECORD from the parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # cloudflare-dyndns
+ 
+In this version it's possible to update all subdomains with a single web request
+
 
 Middleware for updating [Cloudflare](https://www.cloudflare.com/) DNS records through an [AVM FRITZ!Box](https://en.avm.de/products/fritzbox/).
 


### PR DESCRIPTION
This is useful when people need all of the subdomains to be redirected to the same IP (e.g for reverse proxying)