### PR TITLE
allow updating root of zone (no record)

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,8 +20,6 @@ def main():
         return flask.jsonify({'status': 'error', 'message': 'Missing token URL parameter.'}), 400
     if not zone:
         return flask.jsonify({'status': 'error', 'message': 'Missing zone URL parameter.'}), 400
-    if not record:
-        return flask.jsonify({'status': 'error', 'message': 'Missing record URL parameter.'}), 400
     if not ipv4 and not ipv6:
         return flask.jsonify({'status': 'error', 'message': 'Missing ipv4 or ipv6 URL parameter.'}), 400
 
@@ -31,16 +29,18 @@ def main():
         if not zones:
             return flask.jsonify({'status': 'error', 'message': 'Zone {} does not exist.'.format(zone)}), 404
 
+        record_zone_concat = '{}.{}'.format(record, zone) if record is not None else zone
+
         a_record = cf.zones.dns_records.get(zones[0]['id'], params={
-                                            'name': '{}.{}'.format(record, zone), 'match': 'all', 'type': 'A'})
+                                            'name': record_zone_concat, 'match': 'all', 'type': 'A'})
         aaaa_record = cf.zones.dns_records.get(zones[0]['id'], params={
-                                               'name': '{}.{}'.format(record, zone), 'match': 'all', 'type': 'AAAA'})
+                                            'name': record_zone_concat, 'match': 'all', 'type': 'AAAA'})
 
         if ipv4 is not None and not a_record:
-            return flask.jsonify({'status': 'error', 'message': 'A record for {}.{} does not exist.'.format(record, zone)}), 404
+            return flask.jsonify({'status': 'error', 'message': f'A record for {record_zone_concat} does not exist.'}), 404
 
         if ipv6 is not None and not aaaa_record:
-            return flask.jsonify({'status': 'error', 'message': 'AAAA record for {}.{} does not exist.'.format(record, zone)}), 404
+            return flask.jsonify({'status': 'error', 'message': f'AAAA record for {record_zone_concat} does not exist.'}), 404
 
         if ipv4 is not None and a_record[0]['content'] != ipv4:
             cf.zones.dns_records.put(zones[0]['id'], a_record[0]['id'], data={


### PR DESCRIPTION
Title is self-explanatory. I was unable to update my root (@) record through the middleware since it always expects a record.
The few lines got rid of the limitation.
Code is tested for updating root as well as non-root records for ipv4. (ipv6 should not be any different)
Thanks!

Edit: changes in docker-hub repo "philgreedy/cloudflare-dyndns:latest"