### PR TITLE
Pin cloudflare dependency to v2.19.x to suppress v2.20 deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cloudflare~=2.0
+cloudflare~=2.19.0
 Flask~=2.0
 waitress~=3.0


### PR DESCRIPTION
### Motivation
- Pin the `cloudflare` package to the `2.19` series to prevent automatic upgrades to `2.20.x`, which emits a `PendingDeprecationWarning` and recommends breaking migration to `3.x`.

### Description
- Update `requirements.txt` to change `cloudflare~=2.0` to `cloudflare~=2.19.0` so the project stays on the last compatible 2.x line.

### Testing
- Ran `python -m py_compile app.py` to verify the application file compiles successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb379455e08328a9a7fe44276c55e8)