### PR TITLE
fix: install build-essential in the Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,19 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never \
     PIP_NO_CACHE_DIR=1
 
+# build-essential is needed here (but not in the runtime stage) because
+# uvicorn[standard]'s C-extension deps (httptools, uvloop) have no
+# prebuilt wheels for linux/arm/v7 (and sometimes linux/arm64 depending on
+# the Python version), so `uv sync` falls back to compiling them from
+# source under QEMU emulation during the multi-arch release build.
+# DL3008 is intentionally not followed: build-essential is a metapackage
+# discarded with this stage, never shipped in the runtime image, so
+# pinning it to a Debian point-release buys no meaningful reproducibility.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir uv==0.8.17
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

The `Release` workflow's multi-arch build (`linux/amd64`, `linux/arm64`, `linux/arm/v7`) [failed on `main`](https://github.com/L480/cloudflare-dyndns/actions/runs/31421988565) right after #40 merged:

```
error: command 'gcc' failed: No such file or directory
help: `httptools` (v0.8.0) was included because `cloudflare-dyndns` (v0.0.0)
      depends on `uvicorn[standard]` (v0.52.1) which depends on `httptools`
```

**Root cause:** `uvicorn[standard]` pulls in C-extension dependencies (`httptools`, `uvloop`) that have no prebuilt wheels for `linux/arm/v7`, so `uv sync` falls back to compiling them from source under QEMU emulation during the multi-arch build. `python:3.13-slim-bookworm` deliberately ships without a compiler, so that source build fails.

**Fix:** install `build-essential` in the Docker builder stage only — it's discarded before the final `COPY --from=builder`, so this doesn't affect the shipped runtime image's size or attack surface.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` (105 tests, 90.7% coverage)
- [x] Verified clean with the `hadolint` 2.15.1 binary directly
- [ ] Could not re-run the actual multi-arch `buildx` build locally (no Docker daemon in the development sandbox) — **please watch the next `Release` run on merge** to confirm the fix holds for `linux/arm/v7` and `linux/arm64`.

## Breaking changes

None — builder-stage-only change, runtime image unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_