### PR TITLE
chore(deps): consolidate all open Dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -53,7 +53,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -62,7 +62,7 @@ jobs:
       - run: uv sync --all-extras --dev --python ${{ matrix.python-version }}
       - run: uv run pytest
       - if: matrix.python-version == '3.13'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: .coverage
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: hadolint/hadolint-action@v3.4.0
         with:
           dockerfile: Dockerfile
 
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
       - uses: helm/chart-testing-action@v2
       - run: ct lint --charts helm-chart --validate-maintainers=false
       - name: helm template (render check)
@@ -141,6 +141,6 @@ jobs:
           format: sarif
           output: trivy-results.sarif
       - if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,17 @@ jobs:
       - name: Lowercase repository owner
         run: echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "${GITHUB_ENV}"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ env.REPO_OWNER }}/cloudflare-dyndns
           tags: |
@@ -54,7 +54,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -93,7 +93,7 @@ jobs:
       - id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - run: |
           helm package helm-chart \
@@ -108,7 +108,7 @@ jobs:
       - uses: sigstore/cosign-installer@v3
       - run: cosign sign-blob --yes "/tmp/chart/cloudflare-dyndns-${{ steps.version.outputs.version }}.tgz" --output-signature "/tmp/chart/cloudflare-dyndns-${{ steps.version.outputs.version }}.tgz.sig"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: helm-chart
           path: /tmp/chart/
@@ -128,7 +128,7 @@ jobs:
         with:
           name: helm-chart
           path: /tmp/chart
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: /tmp/chart/*

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,6 +27,6 @@ jobs:
           format: sarif
           output: trivy-image-results.sarif
       - if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-image-results.sarif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
   "cloudflare>=5,<6",
   "fastapi>=0.115",
-  "uvicorn[standard]>=0.32",
+  "uvicorn[standard]>=0.52.1",
   "pydantic>=2.9",
   "pydantic-settings>=2.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ requires-dist = [
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1" },
 ]
 provides-extras = ["metrics"]
 


### PR DESCRIPTION
## Summary

Consolidates the 11 currently-open Dependabot PRs (#41–#51) into a single commit, so they're reviewed and tested together instead of trickling in one at a time.

**GitHub Actions**
| Action | From → To | Source PR |
|---|---|---|
| `astral-sh/setup-uv` | v5 → v7 | #46 |
| `docker/build-push-action` | v6 → v7 (ci.yml + release.yml) | #51 |
| `docker/setup-qemu-action` | v3 → v4 | #43 |
| `docker/login-action` | v3 → v4 | #45 |
| `docker/metadata-action` | v5 → v6 | #50 |
| `azure/setup-helm` | v4 → v5 (ci.yml + release.yml) | #49 |
| `actions/upload-artifact` | v4 → v7 (ci.yml + release.yml) | #47 |
| `github/codeql-action` (init/analyze/upload-sarif) | v3 → v4 (ci.yml, codeql.yml, scan.yml) | #48 |
| `softprops/action-gh-release` | v2 → v3 | #44 |
| `hadolint/hadolint-action` | v3.1.0 → v3.4.0 | #42 |

**Python**
- `uvicorn[standard]` floor raised from `>=0.32` to `>=0.52.1` to match what was already resolved in `uv.lock` (#41).
- Re-ran `uv lock --upgrade`: every other dependency was already at its latest resolvable version — no further changes.

## Verification

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` — 105 tests, 90.7% coverage
- [x] `hadolint` (2.15.1 binary) clean on `Dockerfile`
- [x] All four workflow files parse as valid YAML
- [x] Spot-checked the `action.yml` of the largest version jumps directly from their new tags (`astral-sh/setup-uv@v7`, `docker/build-push-action@v7`, `actions/upload-artifact@v7`, `softprops/action-gh-release@v3`) to confirm every input this repo uses is still present — no breaking changes for our usage.

## Notes

- Once this merges, Dependabot should auto-close #41–#51 on its next scan since the versions will already be current on `main`. If it doesn't, they can be closed manually referencing this PR.
- No functional/runtime behavior changes — this is CI tooling and a dependency floor only.


---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_