### PR TITLE
ci: add concurrency group to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Group by ref so back-to-back pushes to main supersede each other (like
+  # ci.yml), but each tag gets its own group - a real release build should
+  # never be cancelled mid-push by another one.
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
 jobs:
   image:
     name: Build & push image


### PR DESCRIPTION
## Summary

Noticed this while watching the last two merges: two `Release` runs ended up building in parallel on `main` (one from the `build-essential` fix in #52, a second triggered moments later by the Dependabot-consolidation merge in #53), because `release.yml` had no `concurrency` block — unlike `ci.yml`, which already has one. I cancelled the stale run manually, but the workflow should prevent this itself going forward.

Concurrent runs here are wasteful (the multi-arch build under QEMU emulation is slow) and can race each other pushing the same `edge` tag.

**Fix:** group by `github.ref`, mirroring `ci.yml`'s pattern, but only `cancel-in-progress` on `main`:
- Back-to-back pushes to `main` now supersede each other, same as CI.
- A `v*` tag build is a real release and must never be cancelled mid-push by another run — since the group key includes the ref, each tag already gets its own isolated group regardless.

## Test plan

- [x] YAML parses correctly
- [x] Not a functional/runtime change — CI/release pipeline behavior only


---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_