### PR TITLE
fix: install the metrics extra in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,12 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev
+    uv sync --frozen --no-install-project --no-dev --extra metrics
 
 COPY src/ src/
 COPY README.md LICENSE ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --extra metrics
 
 # hadolint ignore=DL3006
 FROM ${PYTHON_IMAGE} AS runtime


### PR DESCRIPTION
## Summary

Setting `CFDD_METRICS_ENABLED=true` crashes the container on startup:

```
File "/app/src/cloudflare_dyndns/app.py", line 73, in _mount_metrics
    from prometheus_client import make_asgi_app
ModuleNotFoundError: No module named 'prometheus_client'
```

**Root cause:** `prometheus-client` is declared as an optional dependency (`pyproject.toml`'s `metrics` extra), and `_mount_metrics()` lazily imports it only when metrics are enabled. The Dockerfile's `uv sync` calls never passed `--extra metrics` (or `--all-extras`), so the shipped image never actually contains `prometheus-client` — the extra was effectively dead in the container regardless of the setting.

**Fix:** add `--extra metrics` to both `uv sync` invocations in the builder stage, so `prometheus-client` is installed in every image (it's a small, pure-Python dependency — no meaningful size/attack-surface cost to always including it, and it keeps the image usable for both metrics-on and metrics-off deployments without a second image variant).

## Test plan

- [x] `uv sync --frozen --no-dev --extra metrics` installs cleanly
- [x] `create_app(Settings(metrics_enabled=True, ...))` mounts `/metrics` successfully (previously raised `ModuleNotFoundError`)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` (105 tests, 90.66% coverage)
- [x] `hadolint` clean on `Dockerfile`

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_