### PR TITLE
fix: re-pin base image to clear 180+ stale OS CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@
 
 # python:3.13-slim-bookworm, pinned by digest for reproducible builds.
 # Bump by re-resolving the tag and updating both the digest and this comment.
-ARG PYTHON_IMAGE=python:3.13-slim-bookworm@sha256:67a1e1f215ccda113cfc024e8639049257e88f273898f595b61476d128d387e8
+# Re-resolved 2026-08-11: the previous digest had drifted far enough behind
+# that its baked-in Debian packages (perl, zlib, sqlite, libblkid, ...)
+# had accumulated 180+ HIGH/CRITICAL CVEs with upstream fixes already
+# available in a newer bookworm point release - none of these came from
+# our own dependencies, just an aging base-image pin.
+ARG PYTHON_IMAGE=python:3.13-slim-bookworm@sha256:00faa2debb87529f9f0764e9491d8ba400a3678976616c3bd7cb193745ac20d1
 
 # DL3006 is a false positive here: hadolint can't resolve the digest
 # through the ARG substitution above, but PYTHON_IMAGE is pinned by digest.


### PR DESCRIPTION
## Summary

After the `v2.0.0` release published a real image (finally overwriting the stale pre-refactor `:latest`), the nightly Trivy image scan went from 4 open alerts to 181. Nearly all of them (zlib, perl, perl-archive-tar, sqlite, libblkid, ...) are Debian **OS packages baked into the base image**, not anything from our own dependency tree.

**Root cause:** `Dockerfile` pins `python:3.13-slim-bookworm` by digest for reproducibility, but a digest pin also freezes in whatever CVEs existed in the base image's OS packages at pin time. That digest hadn't been re-resolved since it was first set during the refactor, so it had drifted behind newer bookworm point releases carrying upstream security fixes for those same packages.

**Fix:** re-resolve `python:3.13-slim-bookworm` against the Docker Hub registry API and update the pinned digest (`sha256:67a1e1f2...` → `sha256:00faa2de...`).

## Test plan

- [x] New digest resolved directly against `registry-1.docker.io` for the `python:3.13-slim-bookworm` tag (verified via `docker-content-digest` response header)
- [x] `hadolint` clean on `Dockerfile`
- [ ] The actual CVE count drop can only be confirmed by the next Trivy image scan against a rebuilt `:latest`/tagged image - this repo's Release pipeline now only publishes on a `v*` tag push, so this fix won't take effect until the next version tag (e.g. `v2.0.1`) is cut.

## Notes

A digest pin like this will silently go stale again over time. Worth considering a scheduled job (Dependabot's Docker ecosystem, or a small Renovate/cron setup) to periodically re-resolve it - happy to set that up if wanted, didn't want to over-scope this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_