### PR TITLE
fix: ignore unfixed CVEs in Trivy scans to cut alert noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           scan-type: fs
           scan-ref: .
           severity: HIGH,CRITICAL
+          ignore-unfixed: true
           exit-code: "1"
           format: sarif
           output: trivy-results.sarif

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           image-ref: ghcr.io/${{ env.REPO_OWNER }}/cloudflare-dyndns:latest
           severity: HIGH,CRITICAL
+          # Debian's security fixes lag well behind upstream disclosure for
+          # many packages, so without this, Trivy floods Code Scanning with
+          # CVEs that have no available fix yet regardless of how current
+          # the base image digest is - nothing to act on until Debian ships
+          # a patch. This keeps the alert list to things we can actually fix.
+          ignore-unfixed: true
           format: sarif
           output: trivy-image-results.sarif
       - if: always()


### PR DESCRIPTION
## Summary

After `v2.0.0` published a real image, the code-scanning page jumped to 181 open Trivy alerts (zlib, perl, sqlite, libblkid, ...). #57 re-pinned the base image digest on the theory that it had gone stale, but the count barely moved (181 → 183) even against the freshly re-pinned `v2.0.2` image.

The job logs for the re-scan explain why: Trivy correctly detected the new image (`Detected OS family="debian" version="12.15"`, 97 OS packages), but both Trivy invocations run with the default `ignore-unfixed: false` - meaning Trivy reports CVEs that have **no available fix at all yet**, not just ones we're behind on. Debian's security team lags well behind upstream CVE disclosure for a lot of packages, so a large fraction of alerts on any Debian-based image are typically unfixed regardless of how current the base digest is - no digest bump or dependency update can resolve them until Debian ships a patch.

## Fix

Add `ignore-unfixed: true` to both Trivy invocations:
- `scan.yml` (image scan against the published `:latest`)
- `ci.yml` (filesystem/lockfile scan)

This keeps the alert list limited to things we can actually act on (upgrade a version, bump a digest), instead of a growing pile of "nothing to do yet" noise.

## Test plan

- [x] YAML parses correctly for both workflow files
- [x] Not a functional/runtime change - CI/scanning behavior only
- [ ] Actual alert-count drop can only be confirmed by the next scan against a rebuilt image (next `v*` tag, or the nightly `scan.yml` cron)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_