### PR TITLE
fix: upgrade system pip/setuptools to clear remaining Trivy findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,15 @@ LABEL org.opencontainers.image.title="cloudflare-dyndns" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
+# The app runs entirely out of /app/.venv (see PATH below) and never
+# touches the base image's system pip/setuptools, but Trivy still scans
+# them since they're present in the image. Upgrading here (rather than
+# pinning) keeps pace with whatever fixes are newer than what's baked
+# into the upstream python image's ensurepip bootstrap - pip vendors its
+# own copy of msgpack internally, so this also covers that CVE surface.
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir --upgrade pip setuptools
+
 RUN groupadd --gid 10001 appuser \
     && useradd --uid 10001 --gid appuser --no-create-home --shell /usr/sbin/nologin appuser
 


### PR DESCRIPTION
## Summary

After #58 filtered out unfixed-CVE noise, 3 genuine alerts remained, all "Detected by Trivy in Python":
- `setuptools: Path Traversal Vulnerability in setuptools PackageIndex` (High)
- `MessagePack for Python: Out-of-bounds read / crash on Unpacker reuse after a caught error` (High)
- `setuptools: MANIFEST.in exclusion bypass in sdist via Unicode normalization collision (NFC/NFD)` (Medium)

None of these come from our own dependency tree (`uv.lock` has no `setuptools` or `msgpack` entries). They trace back to the base image's **system** Python install: `python:3.13-slim-bookworm` bootstraps `pip` via `ensurepip`, which brings in whatever `setuptools` version was current at that Python build - and `pip` itself vendors an internal copy of `msgpack` (used for its HTTP cache). Our app never touches any of this; it runs entirely out of `/app/.venv` per the `PATH` override, but Trivy scans the whole image regardless of what's actually used at runtime.

## Fix

`RUN pip install --no-cache-dir --upgrade pip setuptools` in the runtime stage, before the `USER` switch. Upgrading (not pinning) intentionally - pinning would just go stale again the same way the base-image digest did in #57.

## Test plan

- [x] `hadolint` clean on `Dockerfile` (added a justified `DL3013` ignore, same pattern as the existing `DL3008` one for `build-essential`)
- [x] Not a functional/runtime change - doesn't touch anything the app itself imports or executes
- [ ] Actual alert clearance can only be confirmed by the next scan against a rebuilt image (next `v*` tag)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_