### PR TITLE
fix: pin msgpack to a patched version to clear remaining Trivy alert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,16 @@ LABEL org.opencontainers.image.title="cloudflare-dyndns" \
 # touches the base image's system pip/setuptools, but Trivy still scans
 # them since they're present in the image. Upgrading here (rather than
 # pinning) keeps pace with whatever fixes are newer than what's baked
-# into the upstream python image's ensurepip bootstrap - pip vendors its
-# own copy of msgpack internally, so this also covers that CVE surface.
+# into the upstream python image's ensurepip bootstrap.
+#
+# msgpack is pinned explicitly (not just left to "pip vendors its own
+# copy"): the latest pip release still vendors msgpack 1.1.2, which
+# predates the fix for GHSA-6v7p-g79w-8964 - that fix only exists on
+# pip's unreleased main branch so far, so relying on pip's own vendor
+# bundle can't clear this finding yet. Installing msgpack as a real
+# top-level package at a fixed version does.
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools "msgpack>=1.2.1"
 
 RUN groupadd --gid 10001 appuser \
     && useradd --uid 10001 --gid appuser --no-create-home --shell /usr/sbin/nologin appuser


### PR DESCRIPTION
## Summary

Consolidates and supersedes the three Copilot-authored PRs opened against the remaining code-scanning alerts (#60, #61, #62) into one working fix.

- **setuptools** (2 alerts, #6 and #7) is already resolved - the system `pip install --upgrade pip setuptools` merged earlier (live since `v2.0.3`) covers it. Copilot's #60/#62 both tried to *also* patch `setuptools` inside `/app/.venv`, but both fail the Docker build smoke test with the same root cause:
  ```
  RUN /app/.venv/bin/pip install --no-cache-dir --upgrade setuptools
  /bin/sh: 1: /app/.venv/bin/pip: not found
  ```
  `uv`-managed virtualenvs don't bundle `pip` inside the venv by default, so this command can never work as written.

- **msgpack** (1 alert, #5) genuinely wasn't covered yet, despite what the existing Dockerfile comment claimed. The last pip/setuptools fix assumed upgrading `pip` would also bring in a patched vendored `msgpack`, but the latest *released* pip (26.2.1) still vendors `msgpack==1.1.2` - the fix for `GHSA-6v7p-g79w-8964` only exists on pip's unreleased `main` branch. Copilot's #61 correctly worked around this by installing `msgpack` as an explicit top-level package instead of relying on pip's internal vendor copy, and its CI (including the Docker build) was fully green - this PR adopts that approach.

## Change

```dockerfile
# before
RUN pip install --no-cache-dir --upgrade pip setuptools

# after
RUN pip install --no-cache-dir --upgrade pip setuptools "msgpack>=1.2.1"
```

## Test plan

- [x] `hadolint` clean on `Dockerfile`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` (105 tests, 90.66% coverage)
- [ ] Actual alert clearance can only be confirmed by the next scan against a rebuilt image (next `v*` tag)

Closing #60, #61, #62 as superseded by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_