### PR TITLE
fix: install a temporary compiler to build msgpack on linux/arm/v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,18 @@ LABEL org.opencontainers.image.title="cloudflare-dyndns" \
 # pip's unreleased main branch so far, so relying on pip's own vendor
 # bundle can't clear this finding yet. Installing msgpack as a real
 # top-level package at a fixed version does.
-# hadolint ignore=DL3013
-RUN pip install --no-cache-dir --upgrade pip setuptools "msgpack>=1.2.1"
+#
+# msgpack ships no linux/arm/v7 wheel, so it has to compile its C
+# extension there. build-essential is installed just for this RUN and
+# purged again in the same layer, so the compiler never ends up in the
+# shipped image (same reasoning as the builder stage, but scoped here
+# since the runtime stage otherwise has no need for a compiler at all).
+# hadolint ignore=DL3008,DL3013
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && pip install --no-cache-dir --upgrade pip setuptools "msgpack>=1.2.1" \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 10001 appuser \
     && useradd --uid 10001 --gid appuser --no-create-home --shell /usr/sbin/nologin appuser


### PR DESCRIPTION
## Summary

The `v2.0.4` release build [failed](https://github.com/L480/cloudflare-dyndns/actions/runs/31518001798) on `linux/arm/v7`:

```
building 'msgpack._cmsgpack' extension
gcc ... -c msgpack/_cmsgpack.c -o build/temp.linux-armv7l-cpython-313/msgpack/_cmsgpack.o
error: [Errno 2] No such file or directory: 'gcc'
ERROR: Failed building wheel for msgpack
```

**Root cause:** `msgpack` (added in #63 to clear the last code-scanning alert) ships prebuilt wheels for `amd64` and `arm64`, but not `linux/arm/v7` - so `pip` falls back to compiling its C extension (`_cmsgpack`) from source there. The `RUN pip install ...` line lives in the **runtime** stage, which has no compiler (only the builder stage installs `build-essential`, and only because it's needed for `httptools`/`uvloop` in the same way).

**Fix:** install `build-essential` immediately before the `pip install`, then purge it with `apt-get purge --auto-remove` in the same layer - so the compiler is available during the build step but never lands in the shipped image. Same reasoning as the existing builder-stage `build-essential` install, just scoped to a single `RUN`.

## Test plan

- [x] `hadolint` clean on `Dockerfile` (added justified `DL3008`/`DL3013` ignores, consistent with the existing builder-stage precedent)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` (105 tests, 90.66% coverage)
- [ ] Could not reproduce the actual multi-arch `arm/v7` compile locally (no Docker daemon in the dev sandbox) - please watch the next tag's Release run to confirm

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJXKvA6N9eoVHqqQWV5qH)_