### PR TITLE
fix: cast Cloudflare TTL to int before reusing it in updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ project does not yet follow strict semantic versioning pre-1.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Cast the TTL read back from Cloudflare's API to `int` before reusing it
+  in a record update. The Cloudflare SDK can return the TTL as a float
+  (e.g. `60.0`), which the `dns.records.edit` endpoint then rejects with
+  `Failed to parse. ttl must be a number.` (closes #65).
+
 ## [1.0.0] - Unreleased
 
 Complete rewrite of the service per `plan.md`.

--- a/src/cloudflare_dyndns/cloudflare_client.py
+++ b/src/cloudflare_dyndns/cloudflare_client.py
@@ -140,7 +140,7 @@ def _to_dns_record(raw: object) -> DnsRecord:
         name=obj.name,
         type=obj.type,
         content=obj.content or "",
-        ttl=obj.ttl,
+        ttl=int(obj.ttl),
         proxied=obj.proxied,
     )
 

--- a/tests/test_cloudflare_client.py
+++ b/tests/test_cloudflare_client.py
@@ -96,6 +96,18 @@ async def test_get_record_missing_returns_none(cf_mock: respx.MockRouter) -> Non
     assert record is None
 
 
+async def test_get_record_normalizes_float_ttl_to_int(cf_mock: respx.MockRouter) -> None:
+    cf_mock.get("/zones/zone123/dns_records").mock(
+        return_value=httpx.Response(200, json=envelope([{**A_RECORD, "ttl": 60.0}]))
+    )
+    cf = _client()
+    async with cf.client_for(TOKEN) as client:
+        record = await cf.get_record(client, TOKEN, "zone123", "www.example.com", "A")
+    assert record is not None
+    assert record.ttl == 60
+    assert isinstance(record.ttl, int)
+
+
 async def test_get_record_cache_hit_issues_no_request(cf_mock: respx.MockRouter) -> None:
     route = cf_mock.get("/zones/zone123/dns_records").mock(
         return_value=httpx.Response(200, json=envelope([A_RECORD]))


### PR DESCRIPTION
## Summary

- The Cloudflare SDK can return a DNS record's TTL as a float (e.g. `60.0`). When that value was later fed straight back into `dns.records.edit()` during an update, Cloudflare's API rejected the request with `Failed to parse. ttl must be a number.` (code 9208), because it only accepts an integer TTL.
- `_to_dns_record()` in `src/cloudflare_dyndns/cloudflare_client.py` now casts `obj.ttl` to `int` when translating the Cloudflare API response into a `DnsRecord`, so the TTL stored/reused is always an int.
- Added a regression test (`test_get_record_normalizes_float_ttl_to_int`) that mocks a record response with `ttl: 60.0` and asserts the parsed `DnsRecord.ttl` is `60` and of type `int`.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

Closes #65

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy` (pre-existing unrelated `prometheus_client` stub warning only, no new errors)
- [x] `uv run pytest` (106 passed, 90.66% coverage)
- [x] `tests/test_api_compat.py` still passes unmodified
- [ ] `docker build` succeeds, if the Dockerfile changed — not applicable, Dockerfile unchanged
- [ ] `helm lint helm-chart`, if the chart changed — not applicable, chart unchanged

## Breaking changes

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_011zNJk3kWxdANHnzA3VfvGj)_