### PR TITLE
Rewrite for FRITZ!OS 8.40+ and the current Cloudflare SDK

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,6 +4,9 @@ jobs:
   cloudflare_dyndns_docker-build-push:
     name: Build and push cloudflare-dyndns docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -22,10 +25,14 @@ jobs:
           echo "REPO_OWNER=$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
       - name: Build and push image to GitHub Packages
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: ./Dockerfile
           context: ./
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm64/v8
-          tags: ghcr.io/${{ env.REPO_OWNER }}/cloudflare-dyndns:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ env.REPO_OWNER }}/cloudflare-dyndns:latest
+            ghcr.io/${{ env.REPO_OWNER }}/cloudflare-dyndns:${{ github.sha }}

--- a/.github/workflows/helmchart-push.yml
+++ b/.github/workflows/helmchart-push.yml
@@ -4,8 +4,11 @@ jobs:
   cloudflare_dyndns_helmchart-push:
     name: Push cloudflare-dyndns helm chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     container:
-      image: docker://alpine/helm:3.9.2
+      image: docker://alpine/helm:3.16.4
       volumes:
         - ${{github.workspace}}:/workspace
     steps:
@@ -16,6 +19,8 @@ jobs:
           echo "REPO_OWNER=$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
       - name: Login to registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io/${{ env.REPO_OWNER }}
+      - name: Lint chart
+        run: helm lint /workspace/helm-chart
       - name: Package chart
         run: helm package /workspace/helm-chart -d /workspace
       - name: Push chart

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+on:
+  push:
+  pull_request:
+jobs:
+  pytest:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest tests -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3-alpine
+FROM python:3.13-alpine
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=8080
 
 WORKDIR /app
 
@@ -7,6 +11,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py ./
 
-CMD [ "python", "./app.py" ]
+RUN adduser -D -H -u 10001 dyndns
+USER 10001
 
-EXPOSE 80
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python -c "import os,urllib.request; urllib.request.urlopen('http://127.0.0.1:'+os.environ['PORT']+'/healthz').read()"
+
+CMD [ "python", "./app.py" ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Middleware for updating [Cloudflare](https://www.cloudflare.com/) DNS records through an [AVM FRITZ!Box](https://en.avm.de/products/fritzbox/).
 
+Built for **FRITZ!OS 8.40 and newer**: the service answers in the DynDNS2 dialect FRITZ!OS expects (`good` / `nochg` / `badauth` …), accepts the API token as the DynDNS password, understands the `<domain>` and `<ip6lanprefix>` placeholders, and talks to Cloudflare through the current [Cloudflare Python SDK](https://github.com/cloudflare/cloudflare-python) (v5, API v4).
+
 ## Getting started
 
 ### Create a Cloudflare API token
@@ -10,6 +12,8 @@ Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) 
 
 ![Create a Cloudflare custom token](./images/create-cloudflare-token.png "Create a Cloudflare custom token")
 
+The A and/or AAAA record you want to keep up to date has to exist in Cloudflare already — cloudflare-dyndns updates records, it does not create them. Set it to any address to begin with; TTL, proxy status and comment are preserved on every update.
+
 ### :rocket: Option 1: Self-host cloudflare-dyndns
 
 #### Run on Docker
@@ -17,7 +21,13 @@ Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) 
 Start cloudflare-dyndns:
 
 ```bash
-docker run -p 80:80 ghcr.io/l480/cloudflare-dyndns:latest
+docker run -p 80:8080 ghcr.io/l480/cloudflare-dyndns:latest
+```
+
+The container listens on port **8080** and runs as an unprivileged user. Optionally pass the API token to the container instead of putting it into the update URL:
+
+```bash
+docker run -p 80:8080 -e CLOUDFLARE_API_TOKEN=<your-token> ghcr.io/l480/cloudflare-dyndns:latest
 ```
 
 #### Run on Kubernetes
@@ -25,8 +35,18 @@ docker run -p 80:80 ghcr.io/l480/cloudflare-dyndns:latest
 Use the [Helm Chart](./helm-chart) to deploy cloudflare-dyndns to Kubernetes or directly [pull it from the repositories OCI registry](https://helm.sh/docs/topics/registries/#enabling-oci-support):
 
 ```bash
-helm pull oci://ghcr.io/l480/charts/cloudflare-dyndns --version 0.1.0
+helm pull oci://ghcr.io/l480/charts/cloudflare-dyndns --version 0.2.0
 ```
+
+To keep the token out of the update URL, put it into a secret and reference it:
+
+```bash
+kubectl create secret generic cloudflare-dyndns --from-literal=token=<your-token>
+helm upgrade --install cloudflare-dyndns oci://ghcr.io/l480/charts/cloudflare-dyndns \
+  --set cloudflareApiToken.existingSecret=cloudflare-dyndns
+```
+
+Terminate TLS in front of the service (for example with an ingress and a Let's Encrypt certificate). A FRITZ!Box will not send updates to an endpoint whose certificate it cannot validate.
 
 ### :cloud: Option 2: Use my free cloud service
 
@@ -38,9 +58,92 @@ https://dyndns.nicoo.org/?token=<pass>&record=www&zone=example.com&ipv4=<ipaddr>
 
 ### Configure your FRITZ!Box
 
-| FRITZ!Box Setting | Value                                                                                                   | Description                                                                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+In FRITZ!OS 8.40+ go to **Internet > Permit Access > DynDNS**, enable DynDNS and pick the provider **Custom**.
+
+| FRITZ!Box Setting | Value                                                                                             | Description                                                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Update URL        | `https://dyndns.nicoo.org/?token=<pass>&record=www&zone=example.com&ipv4=<ipaddr>&ipv6=<ip6addr>` | Replace the URL parameter `record` and `zone` with your domain name. If required you can omit either the `ipv4` or `ipv6` URL parameter. |
-| Domain Name       | www.example.com                                                                                         | The FQDN from the URL parameter `record` and `zone`.                                                                                 |
-| Username          | admin                                                                                                   | You can choose whatever value you want.                                                                                              |
-| Password          | ●●●●●●                                                                                                  | The API token you’ve created earlier.                                                                                                |
+| Domain Name       | www.example.com                                                                                   | The FQDN from the URL parameter `record` and `zone`.                                                                                    |
+| Username          | admin                                                                                             | You can choose whatever value you want.                                                                                                 |
+| Password          | ●●●●●●                                                                                            | The API token you’ve created earlier.                                                                                                   |
+
+Instead of naming the zone and the record explicitly, you can let the FRITZ!Box fill in the domain name it is configured with:
+
+```
+https://dyndns.nicoo.org/?token=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>
+```
+
+cloudflare-dyndns then picks the matching zone from your Cloudflare account itself.
+
+#### Updating a host behind the FRITZ!Box (IPv6)
+
+A FRITZ!Box only knows its own IPv6 address, so `<ip6addr>` points at the box. To keep the AAAA record of a server *behind* the box current, hand over the delegated prefix and the interface identifier of that host:
+
+```
+https://dyndns.nicoo.org/?token=<pass>&record=nas&zone=example.com&ipv4=<ipaddr>&ipv6prefix=<ip6lanprefix>&ipv6suffix=::1234:5678:9abc:def0
+```
+
+The suffix is the part of the server's IPv6 address behind the prefix; it is combined with `<ip6lanprefix>` on every update. On the FRITZ!Box, `Home Network > Network > <device> > IPv6 Interface ID` shows it.
+
+## URL parameters
+
+| Parameter    | Required                     | Description                                                                                              |
+| ------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `token`      | unless sent as the password  | Cloudflare API token. Alternatively sent as the HTTP basic auth password (`<pass>`), as a bearer token, or configured via `CLOUDFLARE_API_TOKEN`. |
+| `zone`       | unless `domain` is used      | Your Cloudflare zone, e.g. `example.com`.                                                                |
+| `record`     | no                           | Host part of the record, e.g. `www`. Omit it to update the zone apex.                                    |
+| `domain`     | unless `zone` is used        | FQDN to update, e.g. `<domain>`. The zone is resolved automatically.                                     |
+| `ipv4`       | one address is required      | New IPv4 address (`<ipaddr>`).                                                                           |
+| `ipv6`       | one address is required      | New IPv6 address (`<ip6addr>`).                                                                          |
+| `myip`       | no                           | DynDNS2 alias accepting a comma-separated IPv4/IPv6 pair.                                                |
+| `ipv6prefix` | no                           | Delegated IPv6 prefix (`<ip6lanprefix>`). Requires `ipv6suffix` and takes precedence over `ipv6`.        |
+| `ipv6suffix` | with `ipv6prefix`            | Interface identifier of the host behind the FRITZ!Box, e.g. `::1234:5678:9abc:def0`.                     |
+| `format`     | no                           | Set to `json` for a JSON response instead of the DynDNS2 plain text one.                                 |
+
+Placeholders that the FRITZ!Box could not substitute (`<ipaddr>`, `0.0.0.0`, `::`, empty values) are ignored instead of being written to DNS, so a box that has no IPv6 yet does not break the IPv4 update.
+
+The endpoint is served at `/`, `/update` and `/nic/update`.
+
+## Response codes
+
+The default response is DynDNS2 plain text, which is what FRITZ!OS understands:
+
+| Response   | HTTP    | Meaning                                                             |
+| ---------- | ------- | --------------------------------------------------------------------- |
+| `good <ip>`  | 200     | Record updated.                                                     |
+| `nochg <ip>` | 200     | Record already pointed at that address.                             |
+| `badauth`  | 401/403 | Token missing, rejected by Cloudflare, or lacking permissions.      |
+| `badagent` | 400     | Missing or unusable address parameters.                             |
+| `notfqdn`  | 400     | Neither `zone` nor a fully qualified `domain` was given.            |
+| `nohost`   | 404     | Zone or A/AAAA record does not exist.                               |
+| `abuse`    | 429     | Cloudflare rate limit reached.                                      |
+| `911`      | 502     | Cloudflare API error — retry later.                                 |
+
+Append `&format=json` (or send `Accept: application/json`) to get `{"status": …, "code": …, "message": …, "ip": …}` instead.
+
+## Configuration
+
+| Environment variable      | Default   | Description                                                     |
+| ------------------------- | --------- | ----------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`    | –         | Fallback token if the request carries none.                     |
+| `PORT`                    | `8080`    | Port to listen on.                                              |
+| `HOST`                    | `0.0.0.0` | Address to bind to.                                             |
+| `THREADS`                 | `4`       | Waitress worker threads.                                        |
+| `LOG_LEVEL`               | `INFO`    | Python log level.                                               |
+| `CLOUDFLARE_TIMEOUT`      | `10`      | Cloudflare API timeout in seconds.                              |
+| `CLOUDFLARE_MAX_RETRIES`  | `2`       | Retries for failed Cloudflare API calls.                        |
+
+## Development
+
+```bash
+pip install -r requirements-dev.txt
+python -m pytest tests
+python app.py
+```
+
+## Upgrading from earlier versions
+
+* Responses are DynDNS2 plain text by default; use `format=json` for the previous JSON body.
+* The container listens on `8080` instead of `80` and runs as a non-root user (`docker run -p 80:8080 …`).
+* Helm chart `0.2.0` maps the service port `80` to the new container port.
+* Existing update URLs keep working — `token`, `zone`, `record`, `ipv4` and `ipv6` are unchanged.

--- a/app.py
+++ b/app.py
@@ -1,64 +1,359 @@
+"""Middleware for updating Cloudflare DNS records from an AVM FRITZ!Box.
+
+Speaks the DynDNS2 dialect that FRITZ!OS 8.40 and newer expect (plain text
+``good``/``nochg``/``badauth`` responses) and talks to Cloudflare through the
+official ``cloudflare`` Python SDK (v5, API v4).
+"""
+
+import ipaddress
+import logging
 import os
-import CloudFlare
-import waitress
+
+import cloudflare
 import flask
+import waitress
+from cloudflare import Cloudflare
+
+# DynDNS2 return codes. FRITZ!OS looks at the first word of the response body
+# and reports "provider returned an error" for anything it does not know.
+GOOD = 'good'
+NOCHG = 'nochg'
+BADAUTH = 'badauth'
+BADAGENT = 'badagent'
+NOTFQDN = 'notfqdn'
+NOHOST = 'nohost'
+ABUSE = 'abuse'
+SERVERERROR = '911'
+
+# Values a FRITZ!Box sends when it has no usable address yet, or when the
+# update URL was pasted without the placeholders being substituted.
+PLACEHOLDERS = {'', 'none', 'null', '0.0.0.0', '::',
+                '<ipaddr>', '<ip6addr>', '<ip6lanprefix>'}
+
+API_TIMEOUT = float(os.environ.get('CLOUDFLARE_TIMEOUT', '10'))
+API_RETRIES = int(os.environ.get('CLOUDFLARE_MAX_RETRIES', '2'))
+
+log = logging.getLogger('cloudflare-dyndns')
 
 
-app = flask.Flask(__name__)
+class DynDnsError(Exception):
+    """An error that maps onto a DynDNS2 return code and an HTTP status."""
+
+    def __init__(self, code, http_status, message):
+        super().__init__(message)
+        self.code = code
+        self.http_status = http_status
+        self.message = message
 
 
-@app.route('/', methods=['GET'])
-def main():
+def wants_json():
+    """FRITZ!Box gets plain text, everything else can ask for JSON."""
+    if flask.request.args.get('format', '').lower() == 'json':
+        return True
+    accept = flask.request.accept_mimetypes
+    return accept['application/json'] > accept['text/plain']
+
+
+def respond(code, http_status, message, ip=None):
+    if wants_json():
+        status = 'success' if code in (GOOD, NOCHG) else 'error'
+        body = {'status': status, 'code': code, 'message': message}
+        if ip:
+            body['ip'] = ip
+        return flask.jsonify(body), http_status
+
+    text = '{} {}'.format(code, ip) if ip else code
+    return flask.Response('{}\n'.format(text), status=http_status,
+                          mimetype='text/plain')
+
+
+def get_token():
+    """Token from the URL, from HTTP basic/bearer auth, or from the environment.
+
+    FRITZ!OS sends the DynDNS password both as ``<pass>`` in the update URL and
+    as HTTP basic auth, so self-hosters can keep the token out of the URL.
+    """
     token = flask.request.args.get('token')
-    zone = flask.request.args.get('zone')
-    record = flask.request.args.get('record')
-    ipv4 = flask.request.args.get('ipv4')
-    ipv6 = flask.request.args.get('ipv6')
-    cf = CloudFlare.CloudFlare(token=token)
+    if token:
+        return token.strip()
 
-    if not token:
-        return flask.jsonify({'status': 'error', 'message': 'Missing token URL parameter.'}), 400
-    if not zone:
-        return flask.jsonify({'status': 'error', 'message': 'Missing zone URL parameter.'}), 400
-    if not ipv4 and not ipv6:
-        return flask.jsonify({'status': 'error', 'message': 'Missing ipv4 or ipv6 URL parameter.'}), 400
+    auth = flask.request.authorization
+    if auth is not None:
+        if auth.type == 'basic' and auth.password:
+            return auth.password.strip()
+        if auth.type == 'bearer' and auth.token:
+            return auth.token.strip()
+
+    token = os.environ.get('CLOUDFLARE_API_TOKEN')
+    if token:
+        return token.strip()
+
+    raise DynDnsError(BADAUTH, 401, 'Missing Cloudflare API token. Pass it as '
+                                    'the token URL parameter or as the DynDNS '
+                                    'password.')
+
+
+def parse_ip(raw, version, source):
+    """Validate one address the FRITZ!Box sent us."""
+    if raw is None:
+        return None
+
+    raw = raw.strip()
+    if raw.lower() in PLACEHOLDERS:
+        log.info('Ignoring unusable %s value %r.', source, raw)
+        return None
 
     try:
-        zones = cf.zones.get(params={'name': zone})
+        address = ipaddress.ip_address(raw)
+    except ValueError:
+        raise DynDnsError(BADAGENT, 400,
+                          'Invalid {} address: {}.'.format(source, raw))
 
-        if not zones:
-            return flask.jsonify({'status': 'error', 'message': 'Zone {} does not exist.'.format(zone)}), 404
+    if address.version != version:
+        raise DynDnsError(BADAGENT, 400,
+                          '{} is not an IPv{} address.'.format(raw, version))
 
-        record_zone_concat = '{}.{}'.format(record, zone) if record is not None else zone
+    if (address.is_unspecified or address.is_loopback or address.is_multicast
+            or address.is_link_local):
+        raise DynDnsError(BADAGENT, 400,
+                          '{} is not a routable address.'.format(raw))
 
-        a_record = cf.zones.dns_records.get(zones[0]['id'], params={
-                                            'name': record_zone_concat, 'match': 'all', 'type': 'A'})
-        aaaa_record = cf.zones.dns_records.get(zones[0]['id'], params={
-                                            'name': record_zone_concat, 'match': 'all', 'type': 'AAAA'})
+    if address.is_private:
+        # DS-Lite and double NAT hand out addresses that are useless in public
+        # DNS, but publishing them is the caller's decision.
+        log.warning('Publishing non-public %s address.', source)
 
-        if ipv4 is not None and not a_record:
-            return flask.jsonify({'status': 'error', 'message': f'A record for {record_zone_concat} does not exist.'}), 404
-
-        if ipv6 is not None and not aaaa_record:
-            return flask.jsonify({'status': 'error', 'message': f'AAAA record for {record_zone_concat} does not exist.'}), 404
-
-        if ipv4 is not None and a_record[0]['content'] != ipv4:
-            cf.zones.dns_records.put(zones[0]['id'], a_record[0]['id'], data={
-                                     'name': a_record[0]['name'], 'type': 'A', 'content': ipv4, 'proxied': a_record[0]['proxied'], 'ttl': a_record[0]['ttl']})
-
-        if ipv6 is not None and aaaa_record[0]['content'] != ipv6:
-            cf.zones.dns_records.put(zones[0]['id'], aaaa_record[0]['id'], data={
-                                     'name': aaaa_record[0]['name'], 'type': 'AAAA', 'content': ipv6, 'proxied': aaaa_record[0]['proxied'], 'ttl': aaaa_record[0]['ttl']})
-    except CloudFlare.exceptions.CloudFlareAPIError as e:
-        return flask.jsonify({'status': 'error', 'message': str(e)}), 500
-
-    return flask.jsonify({'status': 'success', 'message': 'Update successful.'}), 200
+    return str(address)
 
 
-@app.route('/healthz', methods=['GET'])
-def healthz():
-    return flask.jsonify({'status': 'success', 'message': 'OK'}), 200
+def ipv6_from_prefix(prefix, suffix):
+    """Combine the FRITZ!Box ``<ip6lanprefix>`` with a host's interface id.
+
+    A FRITZ!Box only knows its own IPv6 address, so a server behind it has to
+    be addressed as "prefix from the box" plus "suffix of that host".
+    """
+    try:
+        network = ipaddress.IPv6Network(prefix.strip(), strict=False)
+    except ValueError:
+        raise DynDnsError(BADAGENT, 400,
+                          'Invalid IPv6 prefix: {}.'.format(prefix))
+
+    try:
+        interface_id = ipaddress.IPv6Address(suffix.strip())
+    except ValueError:
+        raise DynDnsError(BADAGENT, 400,
+                          'Invalid IPv6 suffix: {}.'.format(suffix))
+
+    address = ipaddress.IPv6Address(
+        int(network.network_address) | int(interface_id))
+
+    if address not in network:
+        raise DynDnsError(BADAGENT, 400,
+                          'Suffix {} does not fit into prefix {}.'.format(
+                              suffix, network.with_prefixlen))
+
+    return str(address)
 
 
-app.secret_key = os.urandom(24)
-waitress.serve(app, host='0.0.0.0', port=80)
+def collect_addresses():
+    """Read ipv4/ipv6 (or the DynDNS2 ``myip`` alias) from the query string."""
+    args = flask.request.args
+    ipv4 = parse_ip(args.get('ipv4'), 4, 'IPv4')
+    ipv6 = parse_ip(args.get('ipv6'), 6, 'IPv6')
+
+    myip = args.get('myip')
+    if myip:
+        for candidate in myip.split(','):
+            candidate = candidate.strip()
+            if candidate.lower() in PLACEHOLDERS:
+                continue
+            try:
+                version = ipaddress.ip_address(candidate).version
+            except ValueError:
+                raise DynDnsError(BADAGENT, 400,
+                                  'Invalid myip address: {}.'.format(candidate))
+            if version == 4 and ipv4 is None:
+                ipv4 = parse_ip(candidate, 4, 'IPv4')
+            elif version == 6 and ipv6 is None:
+                ipv6 = parse_ip(candidate, 6, 'IPv6')
+
+    prefix = args.get('ipv6prefix')
+    suffix = args.get('ipv6suffix')
+    if prefix and prefix.strip().lower() not in PLACEHOLDERS:
+        if not suffix:
+            raise DynDnsError(BADAGENT, 400, 'The ipv6prefix URL parameter '
+                                             'requires an ipv6suffix.')
+        ipv6 = ipv6_from_prefix(prefix, suffix)
+
+    if ipv4 is None and ipv6 is None:
+        raise DynDnsError(BADAGENT, 400, 'Missing ipv4, ipv6 or ipv6prefix URL '
+                                         'parameter.')
+
+    return ipv4, ipv6
+
+
+def resolve_zone(client, domain):
+    """Find the zone a fully qualified ``<domain>`` belongs to.
+
+    Asks for the longest candidate first, so ``www.home.example.com`` lands in
+    the ``home.example.com`` zone if that one is delegated separately.
+    """
+    labels = domain.split('.')
+    for index in range(len(labels) - 1):
+        candidate = '.'.join(labels[index:])
+        zones = client.zones.list(name=candidate).result
+        if zones:
+            return zones[0]
+
+    raise DynDnsError(NOHOST, 404,
+                      'No zone in this account covers {}.'.format(domain))
+
+
+def resolve_target(client):
+    """Work out the zone and the FQDN to update.
+
+    Either ``domain`` (the FRITZ!Box ``<domain>`` placeholder) or ``zone`` plus
+    an optional ``record`` may be used.
+    """
+    args = flask.request.args
+    domain = args.get('domain')
+    zone_name = args.get('zone')
+    record = args.get('record')
+
+    if domain:
+        domain = domain.strip().rstrip('.').lower()
+        if '.' not in domain:
+            raise DynDnsError(NOTFQDN, 400,
+                              '{} is not a fully qualified domain name.'.format(
+                                  domain))
+        zone = resolve_zone(client, domain)
+        return zone, domain
+
+    if not zone_name:
+        raise DynDnsError(NOTFQDN, 400,
+                          'Missing zone or domain URL parameter.')
+
+    zone_name = zone_name.strip().rstrip('.').lower()
+    zones = client.zones.list(name=zone_name).result
+    if not zones:
+        raise DynDnsError(NOHOST, 404,
+                          'Zone {} does not exist.'.format(zone_name))
+
+    record = record.strip().rstrip('.').lower() if record else None
+    fqdn = '{}.{}'.format(record, zone_name) if record else zone_name
+    return zones[0], fqdn
+
+
+def fetch_record(client, zone_id, fqdn, record_type):
+    """Look up the existing A/AAAA record. This service never creates records."""
+    records = client.dns.records.list(zone_id=zone_id, type=record_type,
+                                      name={'exact': fqdn}, match='all').result
+
+    if not records:
+        raise DynDnsError(NOHOST, 404,
+                          '{} record for {} does not exist.'.format(
+                              record_type, fqdn))
+
+    return records[0]
+
+
+def write_record(client, zone_id, record, content):
+    """Point ``record`` at ``content``. True if it changed."""
+    if record.content == content:
+        log.info('%s record for %s already points at %s.',
+                 record.type, record.name, content)
+        return False
+
+    # PATCH the record so ttl, proxied and comment survive the update.
+    payload = {'zone_id': zone_id, 'type': record.type, 'name': record.name,
+               'content': content, 'ttl': record.ttl}
+    if record.proxied is not None:
+        payload['proxied'] = record.proxied
+
+    client.dns.records.edit(record.id, **payload)
+    log.info('Updated %s record for %s: %s -> %s.',
+             record.type, record.name, record.content, content)
+    return True
+
+
+def handle_update():
+    token = get_token()
+    ipv4, ipv6 = collect_addresses()
+
+    client = Cloudflare(api_token=token, timeout=API_TIMEOUT,
+                        max_retries=API_RETRIES)
+    zone, fqdn = resolve_target(client)
+
+    wanted = []
+    if ipv4 is not None:
+        wanted.append(('A', ipv4))
+    if ipv6 is not None:
+        wanted.append(('AAAA', ipv6))
+
+    # Look everything up first, so a missing AAAA record does not leave the A
+    # record already rewritten.
+    pending = [(fetch_record(client, zone.id, fqdn, record_type), content)
+               for record_type, content in wanted]
+
+    changed = False
+    for record, content in pending:
+        changed |= write_record(client, zone.id, record, content)
+
+    reported_ip = ipv4 or ipv6
+    if changed:
+        return respond(GOOD, 200, 'Update successful.', reported_ip)
+    return respond(NOCHG, 200, 'No update required.', reported_ip)
+
+
+def create_app():
+    app = flask.Flask(__name__)
+    app.secret_key = os.urandom(24)
+
+    @app.route('/', methods=['GET'])
+    @app.route('/update', methods=['GET'])
+    @app.route('/nic/update', methods=['GET'])
+    def update():
+        try:
+            return handle_update()
+        except DynDnsError as error:
+            log.warning('Rejected update from %s: %s',
+                        flask.request.remote_addr, error.message)
+            return respond(error.code, error.http_status, error.message)
+        except cloudflare.AuthenticationError:
+            return respond(BADAUTH, 401, 'Cloudflare rejected the API token.')
+        except cloudflare.PermissionDeniedError:
+            return respond(BADAUTH, 403, 'The API token lacks Zone.Zone read '
+                                         'or Zone.DNS edit permissions.')
+        except cloudflare.NotFoundError:
+            return respond(NOHOST, 404, 'Zone or record not found.')
+        except cloudflare.RateLimitError:
+            return respond(ABUSE, 429, 'Cloudflare rate limit reached.')
+        except cloudflare.APIError as error:
+            log.error('Cloudflare API error: %s', error)
+            return respond(SERVERERROR, 502,
+                           'Cloudflare API error: {}'.format(error))
+
+    @app.route('/healthz', methods=['GET'])
+    def healthz():
+        return flask.jsonify({'status': 'success', 'message': 'OK'}), 200
+
+    return app
+
+
+app = create_app()
+
+
+def main():
+    logging.basicConfig(
+        level=os.environ.get('LOG_LEVEL', 'INFO').upper(),
+        format='%(asctime)s %(levelname)s %(name)s %(message)s')
+
+    waitress.serve(app,
+                   host=os.environ.get('HOST', '0.0.0.0'),
+                   port=int(os.environ.get('PORT', '8080')),
+                   threads=int(os.environ.get('THREADS', '4')),
+                   url_scheme=os.environ.get('URL_SCHEME', 'http'))
+
+
+if __name__ == '__main__':
+    main()

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,24 +1,14 @@
 apiVersion: v2
 name: cloudflare-dyndns
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+description: Middleware for updating Cloudflare DNS records from an AVM FRITZ!Box
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+home: https://github.com/L480/cloudflare-dyndns
+sources:
+  - https://github.com/L480/cloudflare-dyndns
+keywords:
+  - cloudflare
+  - dyndns
+  - fritzbox
+# Bumped for the 2026 rewrite: the container now listens on 8080 as a non-root user.
+version: 0.2.0
 appVersion: "latest"

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -49,14 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "cloudflare-dyndns.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "cloudflare-dyndns.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "cloudflare-dyndns.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -32,16 +33,31 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.containerPort | quote }}
+            {{- if .Values.cloudflareApiToken.existingSecret }}
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloudflareApiToken.existingSecret }}
+                  key: {{ .Values.cloudflareApiToken.secretKey }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /healthz
               port: http
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cloudflare-dyndns.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,12 +12,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range . }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -43,19 +32,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -16,16 +16,32 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# Port the application listens on inside the container.
+containerPort: 8080
+
+# Optional: hand the Cloudflare API token to the pod instead of putting it into
+# the FRITZ!Box update URL. The token is then read from CLOUDFLARE_API_TOKEN.
+cloudflareApiToken:
+  existingSecret: ""
+  secretKey: token
+
+# Additional environment variables, e.g. LOG_LEVEL or THREADS.
+env: []
+  # - name: LOG_LEVEL
+  #   value: INFO
 
 service:
   type: ClusterIP
@@ -35,7 +51,6 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
@@ -47,17 +62,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
 
 nodeSelector: {}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest~=8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cloudflare~=2.0
-Flask~=2.0
-waitress~=2.0
+cloudflare~=5.6
+Flask~=3.1
+waitress~=3.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,247 @@
+"""Tests for the FRITZ!Box facing DynDNS endpoint."""
+
+import base64
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import app as dyndns  # noqa: E402
+
+TOKEN = 'test-token'
+ZONE = SimpleNamespace(id='zone-id', name='example.com')
+
+
+def make_record(record_type, content, record_id='record-id',
+                name='www.example.com'):
+    return SimpleNamespace(id=record_id, name=name, type=record_type,
+                           content=content, ttl=1, proxied=False)
+
+
+class FakeClient:
+    """Minimal stand-in for cloudflare.Cloudflare."""
+
+    def __init__(self, zones=(ZONE,), records=()):
+        self._zones = list(zones)
+        self._records = list(records)
+        self.edits = []
+
+        self.zones = SimpleNamespace(list=self._list_zones)
+        self.dns = SimpleNamespace(
+            records=SimpleNamespace(list=self._list_records, edit=self._edit))
+
+    def _list_zones(self, name=None, per_page=None):
+        return _Page([z for z in self._zones
+                      if name is None or z.name == name])
+
+    def _list_records(self, zone_id=None, type=None, name=None, match=None):
+        wanted = name['exact'] if isinstance(name, dict) else name
+        return _Page([r for r in self._records
+                      if r.type == type and r.name == wanted])
+
+    def _edit(self, record_id, **payload):
+        self.edits.append((record_id, payload))
+        return SimpleNamespace(id=record_id, **payload)
+
+
+class _Page(list):
+    """Pagination object: iterable and exposing .result like the real SDK."""
+
+    @property
+    def result(self):
+        return list(self)
+
+
+@pytest.fixture
+def client():
+    return dyndns.app.test_client()
+
+
+@pytest.fixture
+def cloudflare_client():
+    fake = FakeClient(records=[make_record('A', '1.2.3.4'),
+                               make_record('AAAA', '2001:db8::1')])
+    with mock.patch.object(dyndns, 'Cloudflare', return_value=fake):
+        yield fake
+
+
+def get(client, **params):
+    params.setdefault('token', TOKEN)
+    return client.get('/', query_string=params)
+
+
+def test_healthz(client):
+    response = client.get('/healthz')
+    assert response.status_code == 200
+    assert response.get_json()['status'] == 'success'
+
+
+def test_updates_a_record_and_answers_dyndns2(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www', ipv4='9.9.9.9')
+
+    assert response.status_code == 200
+    assert response.mimetype == 'text/plain'
+    assert response.get_data(as_text=True).strip() == 'good 9.9.9.9'
+
+    record_id, payload = cloudflare_client.edits[0]
+    assert record_id == 'record-id'
+    assert payload == {'zone_id': 'zone-id', 'type': 'A',
+                       'name': 'www.example.com', 'content': '9.9.9.9',
+                       'ttl': 1, 'proxied': False}
+
+
+def test_unchanged_address_answers_nochg(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www', ipv4='1.2.3.4')
+
+    assert response.get_data(as_text=True).strip() == 'nochg 1.2.3.4'
+    assert cloudflare_client.edits == []
+
+
+def test_updates_both_records(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www', ipv4='9.9.9.9',
+                   ipv6='2001:db8::99')
+
+    assert response.status_code == 200
+    assert [payload['type'] for _, payload in cloudflare_client.edits] == \
+        ['A', 'AAAA']
+
+
+def test_zone_apex_without_record(client):
+    fake = FakeClient(records=[make_record('A', '1.2.3.4',
+                                           name='example.com')])
+    with mock.patch.object(dyndns, 'Cloudflare', return_value=fake):
+        response = get(client, zone='example.com', ipv4='9.9.9.9')
+
+    assert response.get_data(as_text=True).strip() == 'good 9.9.9.9'
+
+
+def test_domain_parameter_resolves_zone(client, cloudflare_client):
+    response = get(client, domain='www.example.com.', ipv4='9.9.9.9')
+
+    assert response.get_data(as_text=True).strip() == 'good 9.9.9.9'
+    assert cloudflare_client.edits[0][1]['zone_id'] == 'zone-id'
+
+
+def test_domain_outside_account_is_nohost(client, cloudflare_client):
+    response = get(client, domain='www.example.org', ipv4='9.9.9.9')
+
+    assert response.status_code == 404
+    assert response.get_data(as_text=True).strip() == 'nohost'
+
+
+def test_basic_auth_password_is_used_as_token(client, cloudflare_client):
+    credentials = base64.b64encode(b'admin:' + TOKEN.encode()).decode()
+    response = client.get('/', query_string={'zone': 'example.com',
+                                             'record': 'www',
+                                             'ipv4': '9.9.9.9'},
+                          headers={'Authorization': 'Basic ' + credentials})
+
+    assert response.get_data(as_text=True).strip() == 'good 9.9.9.9'
+
+
+def test_missing_token_is_badauth(client, cloudflare_client):
+    response = client.get('/', query_string={'zone': 'example.com',
+                                             'ipv4': '9.9.9.9'})
+
+    assert response.status_code == 401
+    assert response.get_data(as_text=True).strip() == 'badauth'
+
+
+def test_ipv6_prefix_and_suffix_are_combined(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www',
+                   ipv6prefix='2001:db8:abc:def::/64', ipv6suffix='::dead:beef')
+
+    assert response.status_code == 200
+    _, payload = cloudflare_client.edits[0]
+    assert payload['content'] == '2001:db8:abc:def::dead:beef'
+
+
+def test_ipv6_prefix_without_suffix_is_rejected(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www',
+                   ipv6prefix='2001:db8:abc:def::/64')
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True).strip() == 'badagent'
+
+
+def test_unsubstituted_placeholders_are_ignored(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www', ipv4='9.9.9.9',
+                   ipv6='<ip6addr>')
+
+    assert response.status_code == 200
+    assert [payload['type'] for _, payload in cloudflare_client.edits] == ['A']
+
+
+def test_request_without_any_address_is_badagent(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www')
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True).strip() == 'badagent'
+
+
+def test_myip_alias_carries_both_families(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www',
+                   myip='9.9.9.9,2001:db8::99')
+
+    assert response.status_code == 200
+    assert [payload['content'] for _, payload in cloudflare_client.edits] == \
+        ['9.9.9.9', '2001:db8::99']
+
+
+def test_link_local_address_is_rejected(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www',
+                   ipv6='fe80::1')
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True).strip() == 'badagent'
+
+
+def test_missing_record_is_nohost(client):
+    fake = FakeClient(records=[])
+    with mock.patch.object(dyndns, 'Cloudflare', return_value=fake):
+        response = get(client, zone='example.com', record='www',
+                       ipv4='9.9.9.9')
+
+    assert response.status_code == 404
+    assert response.get_data(as_text=True).strip() == 'nohost'
+
+
+def test_unknown_zone_is_nohost(client):
+    fake = FakeClient(zones=[])
+    with mock.patch.object(dyndns, 'Cloudflare', return_value=fake):
+        response = get(client, zone='example.net', ipv4='9.9.9.9')
+
+    assert response.status_code == 404
+
+
+def test_json_format_is_available(client, cloudflare_client):
+    response = get(client, zone='example.com', record='www', ipv4='9.9.9.9',
+                   format='json')
+
+    assert response.mimetype == 'application/json'
+    assert response.get_json() == {'status': 'success', 'code': 'good',
+                                   'message': 'Update successful.',
+                                   'ip': '9.9.9.9'}
+
+
+def test_dyndns2_update_path_is_served(client, cloudflare_client):
+    response = client.get('/nic/update',
+                          query_string={'token': TOKEN, 'zone': 'example.com',
+                                        'record': 'www', 'ipv4': '9.9.9.9'})
+
+    assert response.status_code == 200
+
+
+def test_missing_aaaa_record_leaves_a_record_untouched(client):
+    fake = FakeClient(records=[make_record('A', '1.2.3.4')])
+    with mock.patch.object(dyndns, 'Cloudflare', return_value=fake):
+        response = get(client, zone='example.com', record='www',
+                       ipv4='9.9.9.9', ipv6='2001:db8::99')
+
+    assert response.status_code == 404
+    assert response.get_data(as_text=True).strip() == 'nohost'
+    assert fake.edits == []


### PR DESCRIPTION
The service was built against cloudflare-python 2.x, whose CloudFlare() client and zones.dns_records.* helpers no longer exist, and it answered every update with JSON, which FRITZ!OS reports as a provider error.

- Port to the cloudflare SDK v5 (Cloudflare client, zones.list, dns.records.list/edit); ttl, proxied and comment survive an update.
- Answer in the DynDNS2 dialect FRITZ!OS understands (good/nochg/badauth/ badagent/notfqdn/nohost/abuse/911); JSON is still available via format=json or an Accept header.
- Accept the API token as the DynDNS password (HTTP basic auth), as a bearer token or from CLOUDFLARE_API_TOKEN, so it need not sit in the URL.
- Support the <domain> placeholder (zone resolved from the account) and <ip6lanprefix> plus an ipv6suffix, so hosts behind the box get correct AAAA records.
- Validate addresses and ignore placeholders the box could not substitute, so a missing IPv6 address no longer breaks the IPv4 update.
- Look up both records before writing either one.
- Serve /update and /nic/update next to /, and start waitress from a main() guard with HOST/PORT/THREADS/LOG_LEVEL configuration.
- Update the image to python:3.13-alpine, run as a non-root user on port 8080 and add a healthcheck; adjust the Helm chart (0.2.0) accordingly with hardened security contexts and an optional token secret.
- Add a pytest suite and a CI workflow, and refresh the README.


Claude-Session: https://claude.ai/code/session_01P5BcndEN9fxf5HHqBykySp

## Summary

<!-- What does this PR change, and why? -->

## Test plan

- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] `uv run mypy`
- [ ] `uv run pytest`
- [ ] `tests/test_api_compat.py` still passes unmodified (or the legacy
      contract change is deliberate and called out below)
- [ ] `docker build` succeeds, if the Dockerfile changed
- [ ] `helm lint helm-chart`, if the chart changed

## Breaking changes

<!-- Anything that changes the legacy `GET /` contract, the container port,
     or default configuration must be called out explicitly here. -->
